### PR TITLE
ODP-2764 Refactor Sqoop to use ambari-python-wrap for all scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -544,7 +544,7 @@ task release(dependsOn: ['checkVersion', 'tar', 'rat']) {
 task relnotes(type: Exec)  {
     workingDir 'src/scripts'
     if (!version.contains('SNAPSHOT')) {
-        commandLine "python", "relnotes.py", "$buildDir/docs", "$projectDir", "$oldHash\\..HEAD", "$version", "$oldVersion"
+        commandLine "ambari-python-wrap", "relnotes.py", "$buildDir/docs", "$projectDir", "$oldHash\\..HEAD", "$version", "$oldVersion"
     } else {
         commandLine "true" //noop
         println "Will not run releasenotes for SNAPSHOT version."

--- a/sqoop-patch-review.py
+++ b/sqoop-patch-review.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python
+#!/usr/bin/env ambari-python-wrap
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/src/scripts/relnotes.py
+++ b/src/scripts/relnotes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env/python
+#!/usr/bin/env ambari-python-wrap
 #
 # Copyright 2011 The Apache Software Foundation
 #


### PR DESCRIPTION
ODP-2764: Refactor Sqoop to use ambari-python-wrap for all scripts

Tested in RHEL9,8 Ubuntu20 and 22 Env's