### PR TITLE
ODP-4589 Handle multiple objects in the list

### DIFF
--- a/ODP-4589_branch_summary.md
+++ b/ODP-4589_branch_summary.md
@@ -1,0 +1,171 @@
+# ODP-4589 Branch Summary: Sqoop HCatalog Deserialization Fixes
+
+## Overview
+The ODP-4589 branch addresses critical compatibility issues in Apache Sqoop's HCatalog integration, specifically focusing on deserialization problems that cause ClassCastException when working with InputJobInfo objects across different Hive/HCatalog versions.
+
+## Problem Statement
+The primary issue was a ClassCastException occurring during Sqoop's HCatalog operations:
+```
+Error: java.lang.ClassCastException: class java.util.LinkedList cannot be cast to class org.apache.hive.hcatalog.mapreduce.InputJobInfo
+```
+
+This error was triggered when `HCatUtil.deserialize()` returned a `java.util.LinkedList` instead of the expected `InputJobInfo` object, typically due to version compatibility issues between HCatalog components.
+
+## Commits Summary
+
+### Commit 1: 3be3eb65d4bb73f9807848091969c2e01302b54a
+**Title:** Fix HCatalog deserialization to handle version compatibility issues (#13)
+**Author:** kravii
+**Date:** Wed Jul 2 21:07:47 2025 -0400
+
+**Changes:**
+- **Initial fix implementation** for ClassCastException in HCatalog deserialization
+- Modified `SqoopHCatImportHelper.java` (line 88) and `SqoopHCatExportHelper.java` (line 112)
+- Replaced unsafe direct casting with type-safe deserialization
+- Added comprehensive error handling with detailed error messages
+- Created documentation file (`sqoop_hcatalog_classcast_fix.md`) explaining the problem and solution
+
+**Key Code Changes:**
+```java
+// Before (unsafe):
+jobInfo = (InputJobInfo) HCatUtil.deserialize(inputJobInfoStr);
+
+// After (type-safe):
+Object deserializedObj = HCatUtil.deserialize(inputJobInfoStr);
+if (deserializedObj instanceof InputJobInfo) {
+  jobInfo = (InputJobInfo) deserializedObj;
+} else {
+  throw new IOException("Failed to deserialize InputJobInfo. Expected InputJobInfo but got " 
+    + (deserializedObj != null ? deserializedObj.getClass().getName() : "null") 
+    + ". This may indicate a version compatibility issue between HCatalog components.");
+}
+```
+
+### Commit 2: df18a6535439db96e7a98e519acbd8c9778beaaf
+**Title:** Fix HCat serialization compatibility by handling List-wrapped InputJobInfo (#15)
+**Author:** kravii
+**Date:** Wed Jul 2 23:49:44 2025 -0400
+
+**Changes:**
+- **Enhanced the initial fix** to handle specific case where InputJobInfo is wrapped in a LinkedList
+- Added logic to unwrap InputJobInfo objects from List containers
+- Applied to both `SqoopHCatImportHelper.java` and `SqoopHCatExportHelper.java`
+
+**Key Enhancement:**
+```java
+} else if (deserializedObj instanceof java.util.List) {
+  // Some Hive/HCat versions wrap InputJobInfo in a LinkedList. Attempt to unwrap.
+  java.util.List<?> list = (java.util.List<?>) deserializedObj;
+  if (!list.isEmpty() && list.get(0) instanceof InputJobInfo) {
+    jobInfo = (InputJobInfo) list.get(0);
+  } else {
+    throw new IOException("Failed to deserialize InputJobInfo. Deserialized as List but did not contain InputJobInfo. List element type: "
+      + (!list.isEmpty() && list.get(0) != null ? list.get(0).getClass().getName() : "unknown") + ".");
+  }
+```
+
+### Commit 3: d409560d938dfbd4cfbebf16ee078896c72a6fc2
+**Title:** Hcat deserialization issue
+**Author:** kravii
+**Date:** Thu Jul 3 00:12:49 2025 -0400
+
+**Changes:**
+- **Code formatting improvements** and additional compatibility enhancements
+- **Major timestamp handling improvements** to support Hive 3.x+ timestamp types
+- **Enhanced date/time conversion logic** with reflection-based compatibility
+- Added support for `org.apache.hadoop.hive.common.type.Timestamp` (Hive 3.x+)
+- Added support for `org.apache.hadoop.hive.common.type.Date` with fallback to `java.sql.Date`
+
+**Key Enhancements:**
+
+1. **Timestamp Conversion in Export Helper:**
+```java
+// Enhanced timestamp handling with reflection-based conversion
+if (val instanceof Timestamp) {
+  tsObj = (Timestamp) val;
+} else {
+  // Attempt reflection-based conversion from Hive's internal Timestamp class
+  try {
+    String hiveTsClassName = "org.apache.hadoop.hive.common.type.Timestamp";
+    if (val.getClass().getName().equals(hiveTsClassName)) {
+      String tsString = val.toString();
+      tsObj = Timestamp.valueOf(tsString);
+    }
+  } catch (Throwable ignore) {
+    // Fallback handled below
+  }
+}
+```
+
+2. **Date Creation with Hive Compatibility:**
+```java
+private Object createHiveDate(long timeMillis, String dateString) {
+  // Attempt to create Hive's Date class when available
+  try {
+    Class<?> hiveDateClazz = Class.forName("org.apache.hadoop.hive.common.type.Date", false,
+            Thread.currentThread().getContextClassLoader());
+    // Try valueOf(String), ofEpochMilli(long), or constructor
+  } catch (ClassNotFoundException cnfe) {
+    // Fall back to java.sql.Date
+  }
+  return new Date(timeMillis);
+}
+```
+
+## Files Modified
+
+1. **`src/java/org/apache/sqoop/mapreduce/hcat/SqoopHCatImportHelper.java`**
+   - Enhanced InputJobInfo deserialization with type safety
+   - Added List unwrapping capability
+   - Improved timestamp/date conversion with Hive 3.x+ compatibility
+   - Added `createHiveDate()` helper method
+
+2. **`src/java/org/apache/sqoop/mapreduce/hcat/SqoopHCatExportHelper.java`**
+   - Enhanced InputJobInfo deserialization with type safety
+   - Added List unwrapping capability
+   - Improved timestamp conversion with reflection-based compatibility
+   - Enhanced error handling for timestamp conversion
+
+3. **`sqoop_hcatalog_classcast_fix.md`** (New file)
+   - Comprehensive documentation of the problem and solution
+   - Detailed explanation of root causes and implementation
+
+## Benefits Achieved
+
+### 1. **Type Safety**
+- Eliminated ClassCastException crashes
+- Proper type checking before casting operations
+- Graceful handling of unexpected deserialization results
+
+### 2. **Version Compatibility**
+- Support for multiple Hive/HCatalog versions
+- Handles both legacy and modern timestamp/date types
+- Reflection-based adaptation for different Hive versions
+
+### 3. **Error Reporting**
+- Clear, actionable error messages
+- Detailed type information for debugging
+- Helps identify specific compatibility issues
+
+### 4. **Robustness**
+- Multiple fallback mechanisms
+- Handles edge cases in deserialization
+- Maintains backward compatibility
+
+## Testing Considerations
+
+1. **Cross-version testing** with different Hive/HCatalog versions
+2. **Import/Export operation validation** for both modified helpers
+3. **Timestamp/Date handling verification** across different Hive versions
+4. **Error message validation** for debugging scenarios
+
+## Impact Analysis
+
+This fix resolves a critical runtime issue that was causing Sqoop jobs to fail when working with HCatalog across different Hadoop ecosystem versions. The solution provides:
+
+- **Immediate stability** by preventing crashes
+- **Future compatibility** through reflection-based adaptation
+- **Better debugging** through detailed error reporting
+- **Minimal performance impact** while maintaining robustness
+
+The changes are backward compatible and maintain the existing API while adding essential error handling and version compatibility features.

--- a/ODP-4589_branch_summary.md
+++ b/ODP-4589_branch_summary.md
@@ -169,3 +169,20 @@ This fix resolves a critical runtime issue that was causing Sqoop jobs to fail w
 - **Minimal performance impact** while maintaining robustness
 
 The changes are backward compatible and maintain the existing API while adding essential error handling and version compatibility features.
+
+## Latest Enhancement: Comprehensive List Validation
+
+**Additional Fix Applied:** Enhanced the list deserialization logic in both helper classes to properly handle multiple objects in the list returned by `HCatUtil.deserialize()`.
+
+### Enhanced Features:
+- **Complete list validation**: Checks all elements in the list, not just the first one
+- **Detailed logging**: Provides comprehensive information about list contents for debugging
+- **Multiple scenario handling**: Gracefully handles empty lists, single InputJobInfo, multiple InputJobInfo objects, and mixed object types
+- **Enhanced error reporting**: Clear error messages with full context about deserialization issues
+- **Backward compatibility**: Maintains existing functionality while adding robustness
+
+### Files Enhanced:
+- `src/java/org/apache/sqoop/mapreduce/hcat/SqoopHCatImportHelper.java` - Enhanced deserialization validation
+- `src/java/org/apache/sqoop/mapreduce/hcat/SqoopHCatExportHelper.java` - Enhanced deserialization validation
+
+This enhancement ensures that no objects in the deserialized list are silently ignored and provides visibility into potential serialization compatibility issues across different Hive/HCatalog versions.

--- a/hcatalog_deserialization_improvements.md
+++ b/hcatalog_deserialization_improvements.md
@@ -1,0 +1,192 @@
+# Recommended Improvements for HCatalog Deserialization Logic
+
+## Current Issue Analysis
+
+The current implementation in the ODP-4589 branch only checks and uses the first element of the list when `HCatUtil.deserialize()` returns a `LinkedList`, but doesn't handle or validate other objects in the list:
+
+```java
+if (!list.isEmpty() && list.get(0) instanceof InputJobInfo) {
+    jobInfo = (InputJobInfo) list.get(0);
+} else {
+    // Error handling for first element only
+}
+```
+
+## Problems with Current Approach
+
+1. **Silent data loss**: Other objects in the list are completely ignored
+2. **Potential masking of issues**: Multiple InputJobInfo objects might indicate a real problem
+3. **Poor debugging support**: No logging about list contents
+4. **Incomplete validation**: Only first element is type-checked
+
+## Recommended Enhanced Implementation
+
+### Option 1: Comprehensive Validation (Recommended)
+
+```java
+} else if (deserializedObj instanceof java.util.List) {
+    java.util.List<?> list = (java.util.List<?>) deserializedObj;
+    
+    if (list.isEmpty()) {
+        throw new IOException("Failed to deserialize InputJobInfo. Deserialized as empty List. " +
+                "This may indicate a serialization issue.");
+    }
+    
+    // Validate all elements in the list
+    int inputJobInfoCount = 0;
+    InputJobInfo foundJobInfo = null;
+    StringBuilder listContents = new StringBuilder("List contents: [");
+    
+    for (int i = 0; i < list.size(); i++) {
+        Object element = list.get(i);
+        if (i > 0) listContents.append(", ");
+        
+        if (element instanceof InputJobInfo) {
+            inputJobInfoCount++;
+            if (foundJobInfo == null) {
+                foundJobInfo = (InputJobInfo) element;
+            }
+            listContents.append("InputJobInfo@").append(i);
+        } else {
+            listContents.append(element != null ? element.getClass().getSimpleName() : "null").append("@").append(i);
+        }
+    }
+    listContents.append("]");
+    
+    // Log the list contents for debugging
+    LOG.info("HCatalog deserialization returned List with {} elements. {}", list.size(), listContents.toString());
+    
+    if (inputJobInfoCount == 0) {
+        throw new IOException("Failed to deserialize InputJobInfo. Deserialized as List but contained no InputJobInfo objects. " + 
+                listContents.toString());
+    } else if (inputJobInfoCount == 1) {
+        // Expected case: exactly one InputJobInfo (possibly with other objects)
+        if (list.size() > 1) {
+            LOG.warn("HCatalog deserialization returned List with {} elements but only 1 InputJobInfo. " +
+                    "Using the InputJobInfo and ignoring other elements. {}", list.size(), listContents.toString());
+        }
+        jobInfo = foundJobInfo;
+    } else {
+        // Multiple InputJobInfo objects - this might indicate a real issue
+        LOG.error("HCatalog deserialization returned List with {} InputJobInfo objects. " +
+                "This is unexpected and may indicate a serialization compatibility issue. " +
+                "Using the first InputJobInfo. {}", inputJobInfoCount, listContents.toString());
+        jobInfo = foundJobInfo;
+    }
+}
+```
+
+### Option 2: Simple Validation with Detailed Logging
+
+```java
+} else if (deserializedObj instanceof java.util.List) {
+    java.util.List<?> list = (java.util.List<?>) deserializedObj;
+    
+    if (list.isEmpty()) {
+        throw new IOException("Failed to deserialize InputJobInfo. Deserialized as empty List.");
+    }
+    
+    // Log list contents for debugging
+    LOG.info("HCatalog deserialization returned List with {} elements", list.size());
+    for (int i = 0; i < Math.min(list.size(), 10); i++) { // Log first 10 elements
+        Object element = list.get(i);
+        LOG.debug("List element[{}]: {}", i, element != null ? element.getClass().getName() : "null");
+    }
+    
+    if (list.get(0) instanceof InputJobInfo) {
+        jobInfo = (InputJobInfo) list.get(0);
+        
+        // Warn if there are additional elements
+        if (list.size() > 1) {
+            LOG.warn("HCatalog deserialization returned List with {} elements. Using first element (InputJobInfo) " +
+                    "and ignoring {} other elements. This may indicate a version compatibility issue.", 
+                    list.size(), list.size() - 1);
+        }
+    } else {
+        throw new IOException("Failed to deserialize InputJobInfo. Deserialized as List but first element is not InputJobInfo. " +
+                "First element type: " + (list.get(0) != null ? list.get(0).getClass().getName() : "null") + 
+                ". List size: " + list.size());
+    }
+}
+```
+
+### Option 3: Configuration-Driven Behavior
+
+```java
+} else if (deserializedObj instanceof java.util.List) {
+    java.util.List<?> list = (java.util.List<?>) deserializedObj;
+    
+    if (list.isEmpty()) {
+        throw new IOException("Failed to deserialize InputJobInfo. Deserialized as empty List.");
+    }
+    
+    // Check configuration for strict validation mode
+    boolean strictValidation = conf.getBoolean("hcatalog.deserialization.strict.validation", false);
+    
+    if (strictValidation) {
+        // In strict mode, validate all elements must be InputJobInfo
+        for (int i = 0; i < list.size(); i++) {
+            if (!(list.get(i) instanceof InputJobInfo)) {
+                throw new IOException(String.format(
+                    "Failed to deserialize InputJobInfo. In strict mode, all list elements must be InputJobInfo. " +
+                    "Element[%d] is %s", i, 
+                    list.get(i) != null ? list.get(i).getClass().getName() : "null"));
+            }
+        }
+        
+        if (list.size() > 1) {
+            LOG.warn("Multiple InputJobInfo objects found in strict mode. Using first one. Count: {}", list.size());
+        }
+    }
+    
+    if (list.get(0) instanceof InputJobInfo) {
+        jobInfo = (InputJobInfo) list.get(0);
+        
+        if (list.size() > 1) {
+            LOG.info("HCatalog deserialization returned {} elements. Using first InputJobInfo.", list.size());
+        }
+    } else {
+        throw new IOException("Failed to deserialize InputJobInfo. First element is not InputJobInfo: " +
+                (list.get(0) != null ? list.get(0).getClass().getName() : "null"));
+    }
+}
+```
+
+## Benefits of Enhanced Approach
+
+1. **Better debugging**: Detailed logging helps diagnose serialization issues
+2. **Early problem detection**: Identifies when multiple InputJobInfo objects are present
+3. **Configurable strictness**: Can be tuned based on environment needs
+4. **Comprehensive error messages**: Provides full context for troubleshooting
+5. **Backward compatibility**: Still works with existing data while providing better insights
+
+## Recommended Configuration
+
+Add these properties to allow tuning the behavior:
+
+```xml
+<!-- Enable detailed logging of HCatalog deserialization -->
+<property>
+    <name>hcatalog.deserialization.debug.logging</name>
+    <value>true</value>
+</property>
+
+<!-- Enable strict validation of all list elements -->
+<property>
+    <name>hcatalog.deserialization.strict.validation</name>
+    <value>false</value>
+</property>
+```
+
+## Testing Scenarios
+
+The enhanced implementation should be tested with:
+
+1. **Single InputJobInfo in list** (expected case)
+2. **Multiple InputJobInfo objects in list** (potential issue)
+3. **InputJobInfo plus other object types** (serialization artifact)
+4. **Empty list** (error case)
+5. **List with no InputJobInfo objects** (error case)
+6. **Different Hive/HCatalog version combinations**
+
+This approach transforms a potential silent failure into a well-documented, debuggable process that maintains backward compatibility while providing better operational insights.

--- a/src/java/org/apache/sqoop/mapreduce/hcat/SqoopHCatExportHelper.java
+++ b/src/java/org/apache/sqoop/mapreduce/hcat/SqoopHCatExportHelper.java
@@ -116,11 +116,52 @@ public class SqoopHCatExportHelper {
     } else if (deserializedObj instanceof java.util.List) {
       // Some Hive/HCat versions wrap InputJobInfo in a LinkedList. Attempt to unwrap.
       java.util.List<?> list = (java.util.List<?>) deserializedObj;
-      if (!list.isEmpty() && list.get(0) instanceof InputJobInfo) {
-        jobInfo = (InputJobInfo) list.get(0);
+      
+      if (list.isEmpty()) {
+        throw new IOException("Failed to deserialize InputJobInfo. Deserialized as empty List. " +
+                "This may indicate a serialization issue.");
+      }
+      
+      // Validate all elements in the list for comprehensive debugging
+      int inputJobInfoCount = 0;
+      InputJobInfo foundJobInfo = null;
+      StringBuilder listContents = new StringBuilder("List contents: [");
+      
+      for (int i = 0; i < list.size(); i++) {
+        Object element = list.get(i);
+        if (i > 0) listContents.append(", ");
+        
+        if (element instanceof InputJobInfo) {
+          inputJobInfoCount++;
+          if (foundJobInfo == null) {
+            foundJobInfo = (InputJobInfo) element;
+          }
+          listContents.append("InputJobInfo@").append(i);
+        } else {
+          listContents.append(element != null ? element.getClass().getSimpleName() : "null").append("@").append(i);
+        }
+      }
+      listContents.append("]");
+      
+      // Log the list contents for debugging
+      LOG.info("HCatalog deserialization returned List with " + list.size() + " elements. " + listContents.toString());
+      
+      if (inputJobInfoCount == 0) {
+        throw new IOException("Failed to deserialize InputJobInfo. Deserialized as List but contained no InputJobInfo objects. " + 
+                listContents.toString());
+      } else if (inputJobInfoCount == 1) {
+        // Expected case: exactly one InputJobInfo (possibly with other objects)
+        if (list.size() > 1) {
+          LOG.warn("HCatalog deserialization returned List with " + list.size() + " elements but only 1 InputJobInfo. " +
+                  "Using the InputJobInfo and ignoring other elements. " + listContents.toString());
+        }
+        jobInfo = foundJobInfo;
       } else {
-        throw new IOException("Failed to deserialize InputJobInfo. Deserialized as List but did not contain InputJobInfo. List element type: "
-                + (!list.isEmpty() && list.get(0) != null ? list.get(0).getClass().getName() : "unknown") + ".");
+        // Multiple InputJobInfo objects - this might indicate a real issue
+        LOG.error("HCatalog deserialization returned List with " + inputJobInfoCount + " InputJobInfo objects. " +
+                "This is unexpected and may indicate a serialization compatibility issue. " +
+                "Using the first InputJobInfo. " + listContents.toString());
+        jobInfo = foundJobInfo;
       }
     } else {
       // Handle the case where deserialize returns an unexpected type

--- a/src/java/org/apache/sqoop/mapreduce/hcat/SqoopHCatImportHelper.java
+++ b/src/java/org/apache/sqoop/mapreduce/hcat/SqoopHCatImportHelper.java
@@ -91,11 +91,52 @@ public class SqoopHCatImportHelper {
     } else if (deserializedObj instanceof java.util.List) {
       // Certain Hive/HCat versions wrap InputJobInfo in a LinkedList during serialization.
       java.util.List<?> list = (java.util.List<?>) deserializedObj;
-      if (!list.isEmpty() && list.get(0) instanceof InputJobInfo) {
-        jobInfo = (InputJobInfo) list.get(0);
+      
+      if (list.isEmpty()) {
+        throw new IOException("Failed to deserialize InputJobInfo. Deserialized as empty List. " +
+                "This may indicate a serialization issue.");
+      }
+      
+      // Validate all elements in the list for comprehensive debugging
+      int inputJobInfoCount = 0;
+      InputJobInfo foundJobInfo = null;
+      StringBuilder listContents = new StringBuilder("List contents: [");
+      
+      for (int i = 0; i < list.size(); i++) {
+        Object element = list.get(i);
+        if (i > 0) listContents.append(", ");
+        
+        if (element instanceof InputJobInfo) {
+          inputJobInfoCount++;
+          if (foundJobInfo == null) {
+            foundJobInfo = (InputJobInfo) element;
+          }
+          listContents.append("InputJobInfo@").append(i);
+        } else {
+          listContents.append(element != null ? element.getClass().getSimpleName() : "null").append("@").append(i);
+        }
+      }
+      listContents.append("]");
+      
+      // Log the list contents for debugging
+      LOG.info("HCatalog deserialization returned List with " + list.size() + " elements. " + listContents.toString());
+      
+      if (inputJobInfoCount == 0) {
+        throw new IOException("Failed to deserialize InputJobInfo. Deserialized as List but contained no InputJobInfo objects. " + 
+                listContents.toString());
+      } else if (inputJobInfoCount == 1) {
+        // Expected case: exactly one InputJobInfo (possibly with other objects)
+        if (list.size() > 1) {
+          LOG.warn("HCatalog deserialization returned List with " + list.size() + " elements but only 1 InputJobInfo. " +
+                  "Using the InputJobInfo and ignoring other elements. " + listContents.toString());
+        }
+        jobInfo = foundJobInfo;
       } else {
-        throw new IOException("Failed to deserialize InputJobInfo. Deserialized as List but did not contain InputJobInfo. List element type: "
-                + (!list.isEmpty() && list.get(0) != null ? list.get(0).getClass().getName() : "unknown") + ".");
+        // Multiple InputJobInfo objects - this might indicate a real issue
+        LOG.error("HCatalog deserialization returned List with " + inputJobInfoCount + " InputJobInfo objects. " +
+                "This is unexpected and may indicate a serialization compatibility issue. " +
+                "Using the first InputJobInfo. " + listContents.toString());
+        jobInfo = foundJobInfo;
       }
     } else {
       throw new IOException("Failed to deserialize InputJobInfo. Expected InputJobInfo but got "


### PR DESCRIPTION
Enhance HCatalog deserialization to comprehensively validate and log all elements in deserialized lists.

Previously, when `HCatUtil.deserialize()` returned a `java.util.List`, only the first element was checked for `InputJobInfo`, potentially ignoring other objects or masking serialization compatibility issues. This change iterates through the entire list, logs its full contents, and provides robust error/warning handling for various scenarios (e.g., empty list, no `InputJobInfo`, multiple `InputJobInfo` objects, or `InputJobInfo` mixed with other types). This prevents silent data loss and significantly improves debugging capabilities for HCatalog deserialization across different Hive/HCatalog versions.