### PR TITLE
Fix sqoop protobuf version mismatch for hive import

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,8 +28,8 @@ hbaseVersion=2.5.10.3.2.3.4-2
 hcatalogVersion=3.1.4.3.2.3.4-2
 kryoVersion=3.0.3
 calciteVersion=1.25.0
-# Hive 2.1.1 transitively depends on protobuff 2.5.0
-hiveProtobufVersion=2.5.0
+# Hive standalone metastore now bundles protobuf-java 3.25.5 for CVE fixes
+hiveProtobufVersion=3.25.5
 guavaVersion=32.0.1-jre
 
 accumuloVersion=1.10.4

--- a/ivy/libraries.properties
+++ b/ivy/libraries.properties
@@ -64,7 +64,7 @@ hbase.version=2.5.10.3.2.3.4-2
 hcatalog.version=3.1.4.3.2.3.4-2
 kryo.version=3.0.3
 calcite.version=1.6.0
-hive.protobuf.version=2.5.0
+hive.protobuf.version=3.25.5
 
 jetty.version=9.3.20.v20170531
 jersey.version=1.19.4


### PR DESCRIPTION
Bump Hive protobuf version to `3.25.5` to resolve `NoSuchMethodError` during Sqoop import.

This change aligns Sqoop's protobuf dependency with the upgraded protobuf-java version in Hive's standalone metastore, which was updated for CVE fixes.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1e2daf6-70d1-4698-8814-c3fa4a7bd1de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d1e2daf6-70d1-4698-8814-c3fa4a7bd1de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

