### PR TITLE
ODP-6473: Resolve missing Jackson ASL libraries in Sqoop classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,9 @@ dependencies {
     }
     compile group: 'org.apache.hbase', name: 'hbase-hadoop-compat', version: hbaseVersion
 
+    compile group: 'org.codehaus.jackson', name: 'jackson-core-asl', version: jacksonAslVersion
+    compile group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: jacksonAslVersion
+
     aopCompile group: 'org.aspectj', name: 'aspectjtools', version: aspectjVersion
     aopCompile group: 'org.aspectj', name: 'aspectjrt', version: aspectjVersion
     aopCompile group: 'org.apache.hadoop', name: 'hadoop-common', version: hadoopVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -61,6 +61,8 @@ checkstyleVersion=5.5
 
 version=1.4.8.3.2.3.6-2
 
+jacksonAslVersion=1.9.13
+
 postgresqlVersion=9.2-1003-jdbc4
 
 jettyVersion=9.4.57.v20241219

--- a/gradle/sqoop-package.gradle
+++ b/gradle/sqoop-package.gradle
@@ -41,6 +41,8 @@ dependencies {
     redist group: 'org.apache.commons', name: 'commons-lang3', version: commonslang3Version
     redist group: 'commons-lang', name: 'commons-lang', version: commonslangVersion
     redist group: 'org.apache.parquet', name: 'parquet-avro', version: parquetVersion
+    redist group: 'org.codehaus.jackson', name: 'jackson-core-asl', version: jacksonAslVersion
+    redist group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: jacksonAslVersion
 }
 
 //Jar tasks

--- a/ivy.xml
+++ b/ivy.xml
@@ -129,6 +129,11 @@ under the License.
     <dependency org="com.fasterxml.jackson.core" name="jackson-databind" rev="${jackson-databind.version}"
           conf="common->default;redist->default" />
 
+    <dependency org="org.codehaus.jackson" name="jackson-core-asl" rev="${jackson-asl.version}"
+          conf="common->default;redist->default" />
+    <dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="${jackson-asl.version}"
+          conf="common->default;redist->default" />
+
     <dependency org="org.slf4j" name="slf4j-api" rev="${slf4j.version}"
                 conf="common->default;redist->default" />
 

--- a/ivy/libraries.properties
+++ b/ivy/libraries.properties
@@ -70,3 +70,4 @@ jetty.version=9.3.20.v20170531
 jersey.version=1.19.4
 
 jackson-databind.version=2.9.5
+jackson-asl.version=1.9.13


### PR DESCRIPTION
adding the missing jackson-core-asl and jackson-mapper-asl jars