### PR TITLE
OCR-2495:Fix OracleManager missing importQuery override causing DateSplitter instead of OracleDateSplitter for query-based imports

### DIFF
--- a/src/java/org/apache/sqoop/manager/OracleManager.java
+++ b/src/java/org/apache/sqoop/manager/OracleManager.java
@@ -455,6 +455,18 @@ public class OracleManager
     super.importTable(context);
   }
 
+  @Override
+  public void importQuery(
+      org.apache.sqoop.manager.ImportJobContext context)
+      throws IOException, ImportException {
+    context.setConnManager(this);
+    // Specify the Oracle-specific DBInputFormat so OracleDateSplitter is used
+    // for DATE/TIMESTAMP split columns instead of the generic DateSplitter,
+    // which emits bare string literals incompatible with Oracle.
+    context.setInputFormat(OracleDataDrivenDBInputFormat.class);
+    super.importQuery(context);
+  }
+
   /**
    * Export data stored in HDFS into a table in a database.
    */


### PR DESCRIPTION
Tested in customer environment and passed the usecase.